### PR TITLE
fix(runtime): update `Task` interface

### DIFF
--- a/packages/runtime/src/primitive/task.ts
+++ b/packages/runtime/src/primitive/task.ts
@@ -1,10 +1,15 @@
 import { IdentityContext } from "../types/event";
 
 export interface Task {
-  executionId: string;
-  taskId: string;
+  // NOTE: let `taskId` match the current response, need to discuss the better design and interface change.
+  taskId: TaskId;
   startAt: Date;
   dataProcess: IdentityContext;
   currentLogic?: IdentityContext;
   executedLogics: Array<IdentityContext>;
+}
+
+export interface TaskId {
+  id: string;
+  executionId: string;
 }


### PR DESCRIPTION
Quickly fix the wrong interface definition to match the real variable value.

Current behavior is
(VS Code definition says `ctx.task.taskId` is a string)
<img width="315" alt="未命名" src="https://user-images.githubusercontent.com/23009182/180174613-bc0b2c3d-d970-40fa-bfa4-c3aeae4288f3.png">

(But actually it is a `TaskId` object)
```json
{
	"_status": 200,
	"_metadata": {
		"executionId": "YtTPSDXYAxFdz2GK2Gy-hQ",
		"status": "success",
		"expiration": "2022-07-21T03:11:04.543644988Z"
	},
	"data": {
		"status": "ok",
		"taskId": {
			"executionId": "YtTPSDXYAxFdz2GK2Gy-hQ",
			"id": "sQxt7LEdKXAVMrD_VIV9ag"
		},
		"response": {
			"message": "Hello, Arthur Dent!"
		}
	}
}
```

---
Saffron Deno runtime uses [Task](https://github.com/fstnetwork/saffron/blob/develop/crates/common/src/domain/model/data_process/task.rs#L26-L39) and [TaskId](https://github.com/fstnetwork/saffron/blob/develop/crates/common/src/primitive/task_id.rs#L23-L32) as context task like this:

```typescript
// packages/runtime/src/context/context.ts
export abstract class AbstractContext {
  readonly payload: Payload;
  readonly task: Task;

  constructor() {
    this.payload = initializePayload();
    this.task = initializeTask();
  }
}

function initializeTask(): Task {
  return Deno.core.opSync("op_initialize_task");
}
```