### PR TITLE
chore(deps-dev): bump dependencies

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -3626,7 +3626,7 @@ const RAW_RUNTIME_STATE =
           ["levn", "npm:0.4.1"],\
           ["prelude-ls", "npm:1.2.1"],\
           ["type-check", "npm:0.4.0"],\
-          ["word-wrap", "npm:1.2.3"]\
+          ["word-wrap", "npm:1.2.5"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -4693,10 +4693,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["word-wrap", [\
-      ["npm:1.2.3", {\
-        "packageLocation": "./.yarn/cache/word-wrap-npm-1.2.3-7fb15ab002-08a677e157.zip/node_modules/word-wrap/",\
+      ["npm:1.2.5", {\
+        "packageLocation": "./.yarn/cache/word-wrap-npm-1.2.5-42d00c4b09-1ec6f6089f.zip/node_modules/word-wrap/",\
         "packageDependencies": [\
-          ["word-wrap", "npm:1.2.3"]\
+          ["word-wrap", "npm:1.2.5"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -54,7 +54,7 @@ const RAW_RUNTIME_STATE =
           ["eslint", "npm:8.35.0"],\
           ["eslint-config-airbnb-base", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:15.0.0"],\
           ["eslint-config-airbnb-typescript", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:17.0.0"],\
-          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:8.6.0"],\
+          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:9.1.0"],\
           ["eslint-plugin-import", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:2.27.5"],\
           ["eslint-plugin-n", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:15.6.1"],\
           ["eslint-plugin-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:4.2.1"],\
@@ -186,7 +186,7 @@ const RAW_RUNTIME_STATE =
           ["eslint", "npm:8.35.0"],\
           ["eslint-config-airbnb-base", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:15.0.0"],\
           ["eslint-config-airbnb-typescript", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:17.0.0"],\
-          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:8.6.0"],\
+          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:9.1.0"],\
           ["eslint-plugin-import", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:2.27.5"],\
           ["eslint-plugin-n", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:15.6.1"],\
           ["eslint-plugin-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:4.2.1"],\
@@ -1811,17 +1811,17 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["eslint-config-prettier", [\
-      ["npm:8.6.0", {\
-        "packageLocation": "./.yarn/cache/eslint-config-prettier-npm-8.6.0-00192c9409-dcb22c140e.zip/node_modules/eslint-config-prettier/",\
+      ["npm:9.1.0", {\
+        "packageLocation": "./.yarn/cache/eslint-config-prettier-npm-9.1.0-0e1fd42d7d-411e3b3b1c.zip/node_modules/eslint-config-prettier/",\
         "packageDependencies": [\
-          ["eslint-config-prettier", "npm:8.6.0"]\
+          ["eslint-config-prettier", "npm:9.1.0"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:8.6.0", {\
-        "packageLocation": "./.yarn/__virtual__/eslint-config-prettier-virtual-b8e01b6b13/0/cache/eslint-config-prettier-npm-8.6.0-00192c9409-dcb22c140e.zip/node_modules/eslint-config-prettier/",\
+      ["virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:9.1.0", {\
+        "packageLocation": "./.yarn/__virtual__/eslint-config-prettier-virtual-1dfbded51f/0/cache/eslint-config-prettier-npm-9.1.0-0e1fd42d7d-411e3b3b1c.zip/node_modules/eslint-config-prettier/",\
         "packageDependencies": [\
-          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:8.6.0"],\
+          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:9.1.0"],\
           ["@types/eslint", "npm:8.4.6"],\
           ["eslint", "npm:8.35.0"]\
         ],\
@@ -1994,7 +1994,7 @@ const RAW_RUNTIME_STATE =
           ["@types/eslint-config-prettier", null],\
           ["@types/prettier", "npm:2.7.1"],\
           ["eslint", "npm:8.35.0"],\
-          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:8.6.0"],\
+          ["eslint-config-prettier", "virtual:2daf4495050022dbddcff9d2094d84557fd852ef817c7774cf6ed179a179194059c9712cefe6449a5715508e975364d0a3c1473f47ecf5181c76b614f50d781f#npm:9.1.0"],\
           ["prettier", "npm:2.8.8"],\
           ["prettier-linter-helpers", "npm:1.0.0"]\
         ],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -204,7 +204,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/runtime/",\
         "packageDependencies": [\
           ["@fstnetwork/runtime", "workspace:packages/runtime"],\
-          ["@rollup/plugin-typescript", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.0.0"],\
+          ["@rollup/plugin-typescript", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.1.5"],\
           ["@types/node", "npm:18.15.11"],\
           ["json-schema-to-typescript", "npm:12.0.0"],\
           ["rimraf", "npm:4.4.1"],\
@@ -224,7 +224,7 @@ const RAW_RUNTIME_STATE =
           ["@fstnetwork/tests", "workspace:packages/tests"],\
           ["@fstnetwork/logic", "workspace:packages/logic"],\
           ["@rollup/plugin-node-resolve", "virtual:ab917ed25483d4697ceb0e52882c08cf6979143f94d86fe9b71dcaa5ecb555bdc3699a74208e57c77ba923cd0046347c1f5b3265feee6f12297ec3c7b3c8cfef#npm:15.0.1"],\
-          ["@rollup/plugin-typescript", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.0.0"],\
+          ["@rollup/plugin-typescript", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.1.5"],\
           ["rimraf", "npm:4.4.1"],\
           ["rollup", "npm:3.18.0"],\
           ["tslib", "npm:2.5.3"],\
@@ -355,7 +355,7 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@rollup-plugin-node-resolve-virtual-8eea9c850e/0/cache/@rollup-plugin-node-resolve-npm-15.0.1-3c00b5782e-3620cad07c.zip/node_modules/@rollup/plugin-node-resolve/",\
         "packageDependencies": [\
           ["@rollup/plugin-node-resolve", "virtual:ab917ed25483d4697ceb0e52882c08cf6979143f94d86fe9b71dcaa5ecb555bdc3699a74208e57c77ba923cd0046347c1f5b3265feee6f12297ec3c7b3c8cfef#npm:15.0.1"],\
-          ["@rollup/pluginutils", "virtual:393c3059e13f4b1abcf38aa09f27e44dde31d32a365f13480072675a4d9478063250e76c9116dcb2a31b5f1102c7698b9889038650ef1116cf37202b3a7e23a2#npm:5.0.2"],\
+          ["@rollup/pluginutils", "virtual:cf6b2f51b2d0076b19615b60a30b3cf2c3e410027c9875f8237342dd4509e1e1dbc9a98b425b5d46e28a53abfa459a22dc8b13f119f7ddb14cc32b91e18247f4#npm:5.0.2"],\
           ["@types/resolve", "npm:1.20.2"],\
           ["@types/rollup", null],\
           ["deepmerge", "npm:4.2.2"],\
@@ -372,18 +372,18 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@rollup/plugin-typescript", [\
-      ["npm:11.0.0", {\
-        "packageLocation": "./.yarn/cache/@rollup-plugin-typescript-npm-11.0.0-867f35a277-ea240f1fd6.zip/node_modules/@rollup/plugin-typescript/",\
+      ["npm:11.1.5", {\
+        "packageLocation": "./.yarn/cache/@rollup-plugin-typescript-npm-11.1.5-a19e055f0f-3048c7837b.zip/node_modules/@rollup/plugin-typescript/",\
         "packageDependencies": [\
-          ["@rollup/plugin-typescript", "npm:11.0.0"]\
+          ["@rollup/plugin-typescript", "npm:11.1.5"]\
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.0.0", {\
-        "packageLocation": "./.yarn/__virtual__/@rollup-plugin-typescript-virtual-393c3059e1/0/cache/@rollup-plugin-typescript-npm-11.0.0-867f35a277-ea240f1fd6.zip/node_modules/@rollup/plugin-typescript/",\
+      ["virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.1.5", {\
+        "packageLocation": "./.yarn/__virtual__/@rollup-plugin-typescript-virtual-cf6b2f51b2/0/cache/@rollup-plugin-typescript-npm-11.1.5-a19e055f0f-3048c7837b.zip/node_modules/@rollup/plugin-typescript/",\
         "packageDependencies": [\
-          ["@rollup/plugin-typescript", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.0.0"],\
-          ["@rollup/pluginutils", "virtual:393c3059e13f4b1abcf38aa09f27e44dde31d32a365f13480072675a4d9478063250e76c9116dcb2a31b5f1102c7698b9889038650ef1116cf37202b3a7e23a2#npm:5.0.2"],\
+          ["@rollup/plugin-typescript", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:11.1.5"],\
+          ["@rollup/pluginutils", "virtual:cf6b2f51b2d0076b19615b60a30b3cf2c3e410027c9875f8237342dd4509e1e1dbc9a98b425b5d46e28a53abfa459a22dc8b13f119f7ddb14cc32b91e18247f4#npm:5.0.2"],\
           ["@types/rollup", null],\
           ["@types/tslib", null],\
           ["@types/typescript", null],\
@@ -411,10 +411,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:393c3059e13f4b1abcf38aa09f27e44dde31d32a365f13480072675a4d9478063250e76c9116dcb2a31b5f1102c7698b9889038650ef1116cf37202b3a7e23a2#npm:5.0.2", {\
-        "packageLocation": "./.yarn/__virtual__/@rollup-pluginutils-virtual-28cc98c3d7/0/cache/@rollup-pluginutils-npm-5.0.2-6aa9d0ddd4-7aebf04d5d.zip/node_modules/@rollup/pluginutils/",\
+      ["virtual:cf6b2f51b2d0076b19615b60a30b3cf2c3e410027c9875f8237342dd4509e1e1dbc9a98b425b5d46e28a53abfa459a22dc8b13f119f7ddb14cc32b91e18247f4#npm:5.0.2", {\
+        "packageLocation": "./.yarn/__virtual__/@rollup-pluginutils-virtual-ec84c77cfb/0/cache/@rollup-pluginutils-npm-5.0.2-6aa9d0ddd4-7aebf04d5d.zip/node_modules/@rollup/pluginutils/",\
         "packageDependencies": [\
-          ["@rollup/pluginutils", "virtual:393c3059e13f4b1abcf38aa09f27e44dde31d32a365f13480072675a4d9478063250e76c9116dcb2a31b5f1102c7698b9889038650ef1116cf37202b3a7e23a2#npm:5.0.2"],\
+          ["@rollup/pluginutils", "virtual:cf6b2f51b2d0076b19615b60a30b3cf2c3e410027c9875f8237342dd4509e1e1dbc9a98b425b5d46e28a53abfa459a22dc8b13f119f7ddb14cc32b91e18247f4#npm:5.0.2"],\
           ["@types/estree", "npm:1.0.0"],\
           ["@types/rollup", null],\
           ["estree-walker", "npm:2.0.2"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -156,7 +156,7 @@ const RAW_RUNTIME_STATE =
           ["@fstnetwork/logic", "workspace:packages/logic"],\
           ["@fstnetwork/runtime", "workspace:packages/runtime"],\
           ["rimraf", "npm:4.4.1"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -168,7 +168,7 @@ const RAW_RUNTIME_STATE =
           ["@fstnetwork/logic", "workspace:packages/logic"],\
           ["@fstnetwork/runtime", "workspace:packages/runtime"],\
           ["rimraf", "npm:4.4.1"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -212,7 +212,7 @@ const RAW_RUNTIME_STATE =
           ["rollup-plugin-dts", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:5.2.0"],\
           ["ts-node", "virtual:c21ce1d9cd6d89c78470b6c4e4c8eb3c63e89575be5e5a2bf6d6c4e4ac9b28bb76e26414b0632ae1aa987918ea27ecfccddd3f686ae66fad9f3c686b5b6c28b3#npm:10.9.1"],\
           ["tslib", "npm:2.5.3"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -228,7 +228,7 @@ const RAW_RUNTIME_STATE =
           ["rimraf", "npm:4.4.1"],\
           ["rollup", "npm:3.18.0"],\
           ["tslib", "npm:2.5.3"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -390,7 +390,7 @@ const RAW_RUNTIME_STATE =
           ["resolve", "patch:resolve@npm%3A1.22.1#optional!builtin<compat/resolve>::version=1.22.1&hash=c3c19d"],\
           ["rollup", "npm:3.18.0"],\
           ["tslib", "npm:2.5.3"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "packagePeers": [\
           "@types/rollup",\
@@ -3961,7 +3961,7 @@ const RAW_RUNTIME_STATE =
           ["@types/typescript", null],\
           ["magic-string", "npm:0.29.0"],\
           ["rollup", "npm:3.18.0"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "packagePeers": [\
           "@types/rollup",\
@@ -4384,7 +4384,7 @@ const RAW_RUNTIME_STATE =
           ["create-require", "npm:1.1.1"],\
           ["diff", "npm:4.0.2"],\
           ["make-error", "npm:1.3.6"],\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"],\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"],\
           ["v8-compile-cache-lib", "npm:3.0.1"],\
           ["yn", "npm:3.1.1"]\
         ],\
@@ -4514,17 +4514,17 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["typescript", [\
-      ["patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307", {\
-        "packageLocation": "./.yarn/cache/typescript-patch-7bbffa1f44-cd6f51368b.zip/node_modules/typescript/",\
-        "packageDependencies": [\
-          ["typescript", "patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["patch:typescript@npm%3A4.8.4#optional!builtin<compat/typescript>::version=4.8.4&hash=1a91c8", {\
         "packageLocation": "./.yarn/cache/typescript-patch-14bc8df10f-5d81fd8cf5.zip/node_modules/typescript/",\
         "packageDependencies": [\
           ["typescript", "patch:typescript@npm%3A4.8.4#optional!builtin<compat/typescript>::version=4.8.4&hash=1a91c8"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7", {\
+        "packageLocation": "./.yarn/cache/typescript-patch-71fdfda6a2-1b45cdfb57.zip/node_modules/typescript/",\
+        "packageDependencies": [\
+          ["typescript", "patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^8.35.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
-    "eslint-config-prettier": "^8.6.0",
+    "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-prettier": "^4.2.1",

--- a/packages/loc-logic-sdk/package.json
+++ b/packages/loc-logic-sdk/package.json
@@ -19,6 +19,6 @@
   },
   "devDependencies": {
     "rimraf": "^4.4.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.3.2"
   }
 }

--- a/packages/logic/package.json
+++ b/packages/logic/package.json
@@ -18,6 +18,6 @@
   },
   "devDependencies": {
     "rimraf": "^4.4.1",
-    "typescript": "^4.7.4"
+    "typescript": "^5.3.2"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -21,6 +21,6 @@
     "rollup-plugin-dts": "^5.2.0",
     "ts-node": "^10.9.1",
     "tslib": "^2.5.3",
-    "typescript": "^4.7.4"
+    "typescript": "^5.3.2"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf target"
   },
   "devDependencies": {
-    "@rollup/plugin-typescript": "^11.0.0",
+    "@rollup/plugin-typescript": "^11.1.5",
     "@types/node": "^18.11.9",
     "json-schema-to-typescript": "^12.0.0",
     "rimraf": "^4.4.1",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@rollup/plugin-typescript": "^11.0.0",
+    "@rollup/plugin-typescript": "^11.1.5",
     "rimraf": "^4.4.1",
     "rollup": "^3.18.0",
     "tslib": "^2.5.3",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -17,6 +17,6 @@
     "rimraf": "^4.4.1",
     "rollup": "^3.18.0",
     "tslib": "^2.5.3",
-    "typescript": "^4.7.4"
+    "typescript": "^5.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,7 +84,7 @@ __metadata:
     "@fstnetwork/logic": "workspace:*"
     "@fstnetwork/runtime": "workspace:*"
     rimraf: "npm:^4.4.1"
-    typescript: "npm:^4.7.4"
+    typescript: "npm:^5.3.2"
   languageName: unknown
   linkType: soft
 
@@ -94,7 +94,7 @@ __metadata:
   dependencies:
     "@fstnetwork/runtime": "workspace:*"
     rimraf: "npm:^4.4.1"
-    typescript: "npm:^4.7.4"
+    typescript: "npm:^5.3.2"
   languageName: unknown
   linkType: soft
 
@@ -134,7 +134,7 @@ __metadata:
     rollup-plugin-dts: "npm:^5.2.0"
     ts-node: "npm:^10.9.1"
     tslib: "npm:^2.5.3"
-    typescript: "npm:^4.7.4"
+    typescript: "npm:^5.3.2"
   languageName: unknown
   linkType: soft
 
@@ -148,7 +148,7 @@ __metadata:
     rimraf: "npm:^4.4.1"
     rollup: "npm:^3.18.0"
     tslib: "npm:^2.5.3"
-    typescript: "npm:^4.7.4"
+    typescript: "npm:^5.3.2"
   languageName: unknown
   linkType: soft
 
@@ -3727,13 +3727,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.7.4":
-  version: 4.7.4
-  resolution: "typescript@npm:4.7.4"
+"typescript@npm:^5.3.2":
+  version: 5.3.2
+  resolution: "typescript@npm:5.3.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f056b2313a7df95268ac63dc4ddcb7aed1b7d5a6bbc933d11c3fcd0a77712e16b24bdf4403acc529ade5c27a2a477e25124e899587e8ca3f19685c7ab954c6f3
+  checksum: 415e5fb6611f5713e460bad48039f00bcfdbde53a2f911727862d5aa9c5d5edd250059a419df382d8f031709e15a169c41eb62b6a401da5eec7ac0f4e359d6ac
   languageName: node
   linkType: hard
 
@@ -3747,13 +3747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^4.7.4#optional!builtin<compat/typescript>":
-  version: 4.7.4
-  resolution: "typescript@patch:typescript@npm%3A4.7.4#optional!builtin<compat/typescript>::version=4.7.4&hash=65a307"
+"typescript@patch:typescript@npm%3A^5.3.2#optional!builtin<compat/typescript>":
+  version: 5.3.2
+  resolution: "typescript@patch:typescript@npm%3A5.3.2#optional!builtin<compat/typescript>::version=5.3.2&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: cd6f51368ba0f8c458a44ca8b05684e9cda49acbb4e7dcf40c4720cd1534f68c2d139ec6f179bb9996e6fe9d0c7a04846db55a048f51fd2f3c41fbce0a004971
+  checksum: 1b45cdfb577a78ae7a9a9d0b77a7b772142cb98ba05e4e5aefba7044a028ded885bcecef63166407a5986645cea816fe4986894336aacd5e791796ea79a6a7ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3858,9 +3858,9 @@ __metadata:
   linkType: hard
 
 "word-wrap@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "word-wrap@npm:1.2.3"
-  checksum: 08a677e1578b9cc367a03d52bc51b6869fec06303f68d29439e4ed647257411f857469990c31066c1874678937dac737c9f8f20d3fd59918fb86b7d926a76b15
+  version: 1.2.5
+  resolution: "word-wrap@npm:1.2.5"
+  checksum: 1ec6f6089f205f83037be10d0c4b34c9183b0b63fca0834a5b3cee55dd321429d73d40bb44c8fc8471b5203d6e8f8275717f49a8ff4b2b0ab41d7e1b563e0854
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,7 +126,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fstnetwork/runtime@workspace:packages/runtime"
   dependencies:
-    "@rollup/plugin-typescript": "npm:^11.0.0"
+    "@rollup/plugin-typescript": "npm:^11.1.5"
     "@types/node": "npm:^18.11.9"
     json-schema-to-typescript: "npm:^12.0.0"
     rimraf: "npm:^4.4.1"
@@ -144,7 +144,7 @@ __metadata:
   dependencies:
     "@fstnetwork/logic": "workspace:*"
     "@rollup/plugin-node-resolve": "npm:^15.0.1"
-    "@rollup/plugin-typescript": "npm:^11.0.0"
+    "@rollup/plugin-typescript": "npm:^11.1.5"
     rimraf: "npm:^4.4.1"
     rollup: "npm:^3.18.0"
     tslib: "npm:^2.5.3"
@@ -264,14 +264,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-typescript@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "@rollup/plugin-typescript@npm:11.0.0"
+"@rollup/plugin-typescript@npm:^11.1.5":
+  version: 11.1.5
+  resolution: "@rollup/plugin-typescript@npm:11.1.5"
   dependencies:
     "@rollup/pluginutils": "npm:^5.0.1"
     resolve: "npm:^1.22.1"
   peerDependencies:
-    rollup: ^2.14.0||^3.0.0
+    rollup: ^2.14.0||^3.0.0||^4.0.0
     tslib: "*"
     typescript: ">=3.7.0"
   peerDependenciesMeta:
@@ -279,7 +279,7 @@ __metadata:
       optional: true
     tslib:
       optional: true
-  checksum: ea240f1fd656329a088fa54eb3f0e3a8b9d9f47cc1c99fcdbf6bccb531763d8c767c7b43c666295d3ae30112576dc464a1f30d0257a5d740863c3ddee11f8070
+  checksum: 3048c7837bcaae3770e6977aa22b34b7da3862f14f25a22249c83867be1a3f78138c0a62b28efd22037890dfd6933e960007da6667a945dcef45f585a581f1aa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,7 +110,7 @@ __metadata:
     eslint: "npm:^8.35.0"
     eslint-config-airbnb-base: "npm:^15.0.0"
     eslint-config-airbnb-typescript: "npm:^17.0.0"
-    eslint-config-prettier: "npm:^8.6.0"
+    eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.27.5"
     eslint-plugin-n: "npm:^15.6.1"
     eslint-plugin-prettier: "npm:^4.2.1"
@@ -1350,14 +1350,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "eslint-config-prettier@npm:8.6.0"
+"eslint-config-prettier@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "eslint-config-prettier@npm:9.1.0"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: dcb22c140e47c74ffa6c55297bf107c2ebd9e594c92b33960f6a21defc5b2842f8bc6af9b79acf3e6f23a776ea770ff2ade3dd9797f4cf051f01eff8ff235347
+  checksum: 411e3b3b1c7aa04e3e0f20d561271b3b909014956c4dba51c878bf1a23dbb8c800a3be235c46c4732c70827276e540b6eed4636d9b09b444fd0a8e07f0fcd830
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- chore(deps-dev): bump typescript from 4.7.4 to 5.3.2
- chore(deps-dev): bump eslint-config-prettier from 8.6.0 to 9.1.0
- chore(deps-dev): bump @rollup/plugin-typescript from 11.0.0 to 11.1.5
- chore(deps): bump word-wrap from 1.2.3 to 1.2.5
